### PR TITLE
Fixed licenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,11 @@ _after_ each `frame` you want to annotate. These notes will then be included as 
 While [Josh Fogg](https://github.com/Foggalong) maintains these versions, they would not have been possible without the work of:
 
 - [Thomas Köppe](https://github.com/tkoeppe), wrote the original `edmaths` style file;
-- [Saturnino Luz](https://www.ed.ac.uk/profile/saturnino-luz), created the Beamer template for the [Usher Institute](https://www.ed.ac.uk/usher);
+- [Saturnino Luz](https://www.ed.ac.uk/profile/saturnino-luz), created the [Beamer template](https://www.overleaf.com/latex/templates/usher-beamer-theme-new/pwjqsqkzhtsy) for the [Usher Institute](https://www.ed.ac.uk/usher);
 - [Ben Brown](https://github.com/bencwbrown), modified the Beamer theme for general UoE usage.
 
-Issues can be flagged [on GitHub](https://github.com/Foggalong/edinburgh-math-latex/issues) by [by email](mailto:j.fogg@ed.ac.uk). The license for the Beamer files is LPPL 3c. The licenses for all other files are [unknown](https://github.com/Foggalong/edinburgh-math-latex/issues/1).
+Issues can be flagged [on GitHub](https://github.com/Foggalong/edinburgh-math-latex/issues) by [by email](mailto:j.fogg@ed.ac.uk).
+
+## Licenses
+
+The stylesheets [edmaths.sty](edmaths.sty) and [beamerthemeedmaths.sty](beamerthemeedmaths.sty) are provided under the [LaTeX Project Public License v1.3c](https://choosealicense.com/licenses/lppl-1.3c/) (LPPL). The examples [example-presentation.tex](example-presentation.tex) and [example-report.tex](example-report.tex) are provided under the [BSD Zero Clause License](https://choosealicense.com/licenses/0bsd/) (0BSD). The images [edinburgh-logo](Images/edinburgh-logo.svg) and [white-tied-in](Images/white-tied-in.svg) are registered trademarks; they are not to be used as part of derived or independent works without the permission of The University of Edinburgh. This does not affect use as part of compiled LaTeX documents using this stylesheet for the university.

--- a/beamerthemeedmaths.sty
+++ b/beamerthemeedmaths.sty
@@ -1,9 +1,29 @@
 %% Package `edmaths' v0.97
+%% File beamerthemeedmaths.sty
+%% Copyright 2022 Josh Fogg
 %%
-%% A LaTeX style file for typesetting presentations for the School of Mathematics at the
-%% University of Edinburgh. Originally written by Saturnino Luz for the Usher Institute
-%% and made generic to UoE by Ben Brown. It has since been updated by Josh Fogg (2020/21).
-%% See README.md for usage instructions.
+%% beamerthemeedmaths.sty is a LaTeX style file for typesetting presentations
+%% for the School of Mathematics at the University of Edinburgh, part of the
+%% more general `edmaths' package. See README.md for usage instructions.
+%%
+%% This work may be distributed and/or modified under the conditions of the
+%% LaTeX Project Public License, either version 1.3 of this license or (at
+%% your option) any later version.
+%%
+%% The latest version of this license is in http://latex-project.org/lppl.txt
+%% and version 1.3 or later is part of all distributions of LaTeX version
+%% 2005/12/01 or later.
+%% 
+%% This work has the LPPL maintenance status `maintained' and the current
+%% maintainer of this work is Josh Fogg. Originally written by Saturnino Luz
+%% for the Usher Institute and made generic to UoE by Ben Brown.
+%%
+%% This work consists of the files beamerthemeedmaths.sty, but in addition
+%% requires images `white-tied-in' and `edinburgh-logo' to compile. The images
+%% distributed with this work in the `edmaths' package are registered trademarks;
+%% they are not to be used as part of derived or independent works without the
+%% permission of The University of Edinburgh. This does not affect use as part
+%% of compiled LaTeX documents using this style for the university.
 
 \ProvidesPackage{beamerthemeedmaths}[2021-07-17 Edinburgh maths beamer theme v0.97]
 \RequirePackage{amsfonts,graphicx,lmodern,times}

--- a/edmaths.sty
+++ b/edmaths.sty
@@ -1,9 +1,25 @@
 %% Package `edmaths' v0.97
+%% File edmaths.sty
+%% Copyright 2022 Josh Fogg
 %%
-%% A LaTeX style file for typesetting reports and theses in the School of Mathematics
-%% at the University of Edinburgh originally written by Thomas Koeppe in 2007/07, it
-%% has since been updated by Josh Fogg (2020/21). Suitable for use for theses, yearly
-%% year reports, and undergraduate projects. See README.md for usage instructions.
+%% edmaths.sty is a LaTeX style file for typesetting reports and theses in the
+%% School of Mathematics at the University of Edinburgh. Suitable for use for
+%% theses, yearly reports, and undergraduate projects. Part of the more general
+%% `edmaths' package. See README.md for usage instructions.
+%%
+%% This work may be distributed and/or modified under the conditions of the
+%% LaTeX Project Public License, either version 1.3 of this license or (at
+%% your option) any later version.
+%%
+%% The latest version of this license is in http://latex-project.org/lppl.txt
+%% and version 1.3 or later is part of all distributions of LaTeX version
+%% 2005/12/01 or later.
+%% 
+%% This work has the LPPL maintenance status `maintained' and the current
+%% maintainer of this work is Josh Fogg. Originally written by Thomas Koeppe in
+%% 2007/07, it has since been updated by Josh Fogg in 2020/21.
+%%
+%% This work consists of the file edmaths.sty.
 
 \NeedsTeXFormat{LaTeX2e}
 \ProvidesPackage{edmaths}[2021-07-17 Edinburgh maths thesis/report style v0.97]

--- a/example-presentation.tex
+++ b/example-presentation.tex
@@ -1,3 +1,10 @@
+%% This file is an example of using beamerthemeedmaths.sty to style a Beamer
+%% presentation. While the style is LPPL 1.3 licensed, this example is given
+%% under a 0BSD license (https://choosealicense.com/licenses/0bsd), meaning
+%% it can be freely used, copied, modified, and/or retributed with or without
+%% attribution. For instructions on using the style, see the README.md file
+%% or https://github.com/Foggalong/edinburgh-math-latex.
+
 \documentclass[notes]{beamer}
 \usetheme{edmaths}
 \usepackage{lipsum}

--- a/example-references.bib
+++ b/example-references.bib
@@ -1,5 +1,7 @@
- The below link contains useful bibtex templates
- https://verbosus.com/bibtex-style-examples.html
+ This is an example biblography used in example-presentation.tex and
+ example-report.tex, examples of the edmaths Beamer and report styles
+ respectively. When creating a biblography you might find these bibtex
+ templates useful: https://verbosus.com/bibtex-style-examples.html
 
 @misc{koeppe2007,
   title = {Package `edmaths'},

--- a/example-report.tex
+++ b/example-report.tex
@@ -1,3 +1,11 @@
+%% This file is an example of using edmaths.sty to style a PhD thesis that
+%% complies with University of Edinburgh typesetting rules. While the
+%% style is LPPL 1.3 licensed, this example is given under a 0BSD license
+%% (https://choosealicense.com/licenses/0bsd), meaning it can be freely
+%% used, copied, modified, and/or retributed with or without attribution.
+%% See README.md or https://github.com/Foggalong/edinburgh-math-latex for
+%% instructions on using the style.
+
 \documentclass[12pt,twoside]{report}
 
 \title{Thesis Title}


### PR DESCRIPTION
Finally sorted the licenses :scroll:  Stylesheets under the permissive LPPL license, examples under the public-domain-eque 0BSD license, and logos with the appropriate trademark notice thanks to the wonderful Lindsay in UoE Legal and Deepthi in Comms.