### PR TITLE
updates margins for twoside

### DIFF
--- a/edmaths.sty
+++ b/edmaths.sty
@@ -33,8 +33,8 @@
 
 \setlength{\paperheight}{297mm}    % A4 Paper
 \setlength{\paperwidth}{210mm}     %
-\setlength{\oddsidemargin}{14.6mm} %  Left/Inside: 4.0cm (rel. -1in)
-\setlength{\evensidemargin}{-.4mm} %  Right/Outside: 2.5cm (rel. -1in)
+\setlength{\oddsidemargin}{-.4mm} %  Left/Inside: 2.5cm (rel. -1in)
+\setlength{\evensidemargin}{14.6mm} %  Right/Outside: 4.0cm (rel. -1in)
 \setlength{\topmargin}{-17.4mm}    % \
 \setlength{\headheight}{6mm}       % | Top: 2.0cm (rel. -1in), out of which 6mm for the header
 \setlength{\headsep}{6mm}          % /
@@ -170,7 +170,7 @@
 \renewcommand{\maketitle}{%
     \begin{titlepage}
         \singlespacing
-        \addtolength{\oddsidemargin}{-0.75cm}
+        \addtolength{\oddsidemargin}{0.75cm}
         \begin{center}
             \null\vskip 4.1cm
             \begin{minipage}[t][7.6cm]{10.5cm}


### PR DESCRIPTION
- Interchanges the `oddsidemargin` and `evensidemargin` parameters so that twosided documents are laid out according to the standard conventions for book printing.

## Type of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Background on the changes:

When creating a report with the `twoside` option, it is prepared to be printed two-sided and bound as a book. The standard for book binding is for odd pages to come on the right of a two-page spread, even pages on the left. Looking at a two-page spread, there should be three strips of vertical white space: a left margin on the left (even) page, a central margin, and a right margin on the right (odd) page. Ideally all three strips should be of a similar size.

The central margin is made up of the inner margins of the two pages of the spread. As such, the inner margin of each page should be about half the size of the outer margin. This requires a different convention for left/right margins on odd vs even pages.

The previous version placed a narrow margin at the outside of each page and a wide margin on the inside, resulting in a very unbalanced page layout. It's possible that the authors imagined a layout with odd pages on the left, which is the opposite of the standard convention. It's also possible they imagined the wider central margin accounted for binding space, but this should be set using the `bindingoffset` parameter of the geometry package.

## Detail on changes:

The parameters responsible for the twoside page layout are `oddsidemargin` and `evensidemargin`. By interchanging these, we obtain a layout that conforms to widely accepted publishing conventions. Even after interchanging, the central  margin is slightly wider than the outer margins, which should account for the small amount of paper that would be taken up by the types of bindings (glue binding) typical of a UoE thesis.

Previously there was a manual correction to the `maketitle` command to ensure the title page is centred. This has been adjusted so that even after the above changes the title page is still centred.
